### PR TITLE
Fixes a crash that prevented non-Constant variables from working in Struct

### DIFF
--- a/DogScepterLib/Project/GML/Compiler/Parser.cs
+++ b/DogScepterLib/Project/GML/Compiler/Parser.cs
@@ -818,7 +818,7 @@ public class Parser
             Node accessor = new(NodeAccessorInfo.Accessors[TokenKind.ArrayOpen]);
             newArg.Children.Add(accessor);
             accessor.Children.Add(new Node(NodeKind.Constant, new Token(ctx, new TokenConstant((double)(argCount++)), -1)));
-            return null;
+            return newArg;
         }
         while (curr.Kind != TokenKind.EOF && curr.Kind != TokenKind.End)
         {


### PR DESCRIPTION
This simple bug would feed `null` into the node children list every time `makeNewArg` was called - causing a compiler crash down the line.